### PR TITLE
Update mmcif_parsing.py to use PDBData instead of SCOPData

### DIFF
--- a/src/alphafold/data/mmcif_parsing.py
+++ b/src/alphafold/data/mmcif_parsing.py
@@ -20,7 +20,7 @@ from typing import Any, Mapping, Optional, Sequence, Tuple
 
 from absl import logging
 from Bio import PDB
-from Bio.Data import SCOPData
+from Bio.Data import PDBData
 
 # Type aliases:
 ChainId = str
@@ -256,7 +256,7 @@ def parse(*,
       author_chain = mmcif_to_author_chain_id[chain_id]
       seq = []
       for monomer in seq_info:
-        code = SCOPData.protein_letters_3to1.get(monomer.id, 'X')
+        code = PDBData.protein_letters_3to1.get(monomer.id, 'X')
         seq.append(code if len(code) == 1 else 'X')
       seq = ''.join(seq)
       author_chain_to_sequence[author_chain] = seq


### PR DESCRIPTION
SCOPData is no longer provided in the most recent versions of Bio.Data, but PDBData provides the same function.